### PR TITLE
[Fix]디자이너 프로필 기본 이미지 넣기 및 둘러보기 탭 undefined 속성 적용

### DIFF
--- a/src/components/designer/DesignerDetail.tsx
+++ b/src/components/designer/DesignerDetail.tsx
@@ -116,7 +116,11 @@ const DesignerDetail = () => {
 						<div className='instagram-noti'>인스타그램에서 새로운 옷들을 발견해 보세요!</div>
 					</DesignerProfile>
 					<div className='designer-profile-img'>
-						<img src={designerInfo?.designerProfile === null ? `/img/myProfile-${randomNumFloor}.png` : designerInfo?.designerProfile} />
+						<img src={designerInfo?.designerProfile === null || designerInfo?.designerProfile === "default" ? 
+							// `/img/myProfile-${randomNumFloor}.png` 
+							`/img/profile-large.png` 
+							: 
+							designerInfo?.designerProfile} />
 					</div>
 				</InfoWrapper>
 				<InstaBtn onClick={()=>onClickToExternel(designerInfo?.instagram!)}><FaInstagram size="2rem" />디자이너 인스타그램 구경하기</InstaBtn>

--- a/src/components/productlist/ListView.tsx
+++ b/src/components/productlist/ListView.tsx
@@ -31,7 +31,7 @@ const ListView = () => {
 	const [savedModalIsOpen, setSavedModalIsOpen] = useState(false);
 	const [unsavedModalIsOpen, setUnsavedModalIsOpen] = useState(false);
 	const [loginModalIsOpen, setLoginModalIsOpen] = useState(false);
-	const [products, setProducts] = useState<ProductType[]>(productList);
+	const [products, setProducts] = useState<ProductType[]|undefined>();
 	// const [products, setProducts] = useState([]);
 
 	const [sketchTab, setSketchTab] = useState('active');
@@ -74,7 +74,7 @@ const ListView = () => {
 		}
 	};
 	useEffect(() => {
-		// setProducts(productList);
+		setProducts(() => undefined);
 		getProducts(activatedTab);
 	}, [activatedTab]);
 
@@ -115,7 +115,7 @@ const ListView = () => {
 			{unsavedModalIsOpen === true && <ModalProductUnsaved />}
 			<ForBlank />
 			<GridWrapper>
-				{products.map((product: ProductType, idx: number) => (
+				{products && products.map((product: ProductType, idx: number) => (
 					<ListCard
 						key={idx}
 						clothesId={product.clothesId}


### PR DESCRIPTION
## 📌 PR 내용
- 디자이너 프로필 기본 이미지 안 뜸 오류 수정
- 둘러보기 탭 바뀔 때 undefined 속성 -> 리렌더링 확실히 적용

## 📝 코드 요약
- `src/components/designer/DesignerDetail.tsx` : 기존 null값 속성에서 default string으로 변경됨. 해당 부분 적용(null 값은 따로 지우지 않음)
- `src/components/productlist/ListView.tsx` : 둘러보기 탭 바뀔 시 undefined 속성 적용시켜 리렌더링 되는 것이 눈에 보이도록 적용.